### PR TITLE
feat SignupScreen 추가

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -1,13 +1,13 @@
 import 'package:flutter/material.dart';
 import 'package:office_shopping_mall/core/constants/app_constants.dart';
 import 'package:office_shopping_mall/core/constants/app_routes.dart';
-import 'package:office_shopping_mall/feature/home/ui/HomeScreen.dart';
+import 'package:office_shopping_mall/feature/auth/ui/signup_screen.dart';
 
 class AppRouter {
   static Route<dynamic> onGenerateRoute(RouteSettings settings) {
     switch (settings.name) {
       case AppRoutes.home:
-        return MaterialPageRoute(builder: (_) => HomeScreen());
+        return MaterialPageRoute(builder: (_) => SignupScreen());
 
       default:
         return MaterialPageRoute(

--- a/lib/feature/auth/ui/auth_header.dart
+++ b/lib/feature/auth/ui/auth_header.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+
+class AuthHeader extends StatelessWidget {
+  const AuthHeader({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return Center(
+      child: Column(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          Container(
+            width: 150,
+            height: 120,
+            color: Colors.blue,
+            alignment: Alignment.center,
+            child: Text("앱 아이콘 위치"),
+          ),
+          SizedBox(height: 16),
+
+          Text(
+            "직장인을 위한 스마트 쇼핑몰",
+            style: GoogleFonts.notoSans(
+                fontWeight: FontWeight.bold,
+                fontSize: 20,
+              letterSpacing: 0.5,
+            )
+          ),
+          SizedBox(height: 56),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/auth/ui/signup_form.dart
+++ b/lib/feature/auth/ui/signup_form.dart
@@ -1,0 +1,223 @@
+import 'package:flutter/material.dart';
+import '../../../core/constants/app_colors.dart';
+
+class SignUpForm extends StatefulWidget {
+  SignUpForm({super.key});
+
+  @override
+  State<StatefulWidget> createState() {
+    return SignUpFormState();
+  }
+}
+
+class SignUpFormState extends State<SignUpForm> {
+  //각 입력마다 유효성 검사를 위한 키
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _nameController = TextEditingController();
+  final TextEditingController _emailController = TextEditingController();
+  final TextEditingController _pwController = TextEditingController();
+  final TextEditingController _confirmPwController = TextEditingController();
+  bool _showVisibleIcon = true;
+
+  void _changeVisibilityIcon() {
+    setState(() {
+      _showVisibleIcon = !_showVisibleIcon;
+    });
+  }
+
+  Map<String, String> getFormData(){
+    return {
+      "nickname": _nameController.text,
+      "email": _emailController.text,
+      "password": _pwController.text
+    };
+  }
+
+  void _submitForm() async{
+    if(_formKey.currentState!.validate()){
+      final confirm = await showDialog<bool>(
+          context: context,
+          builder: (context) => AlertDialog(
+            title: Text("회원가입"),
+            content: Text("입력하신 정보로 가입을 하시겠습니까?"),
+            actions: [
+              TextButton(
+                  onPressed: (){Navigator.of(context).pop(false);},
+                  child: Text("취소")
+              ),
+              TextButton(
+                  onPressed: (){Navigator.of(context).pop(true);},
+                  child: Text("확인")
+              )
+            ],
+          )
+      );
+
+      if(confirm == true){
+        final formData = getFormData();
+        print("$formData");
+        //TODO 회원가입 api
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _pwController.dispose();
+    _emailController.dispose();
+    _nameController.dispose();
+    _confirmPwController.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Form(
+      //각 입력마다 유효성 검사를 위한 키
+        key: _formKey,
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+
+              TextFormField(
+                controller: _nameController,
+                keyboardType: TextInputType.text,
+                textInputAction: TextInputAction.next,
+                decoration: InputDecoration(
+                  contentPadding: EdgeInsets.symmetric(vertical: 12),
+                  enabledBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(color: Colors.grey.shade400, width: 1)
+                  ),
+                  focusedBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(color: Colors.grey.shade200, width: 1.5)
+                  ),
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
+                  labelText: "이름",
+                ),
+                validator: (value){
+                  if(_nameController.text.isEmpty){
+                    return "이름을 입력해주세요.";
+                  }
+                  return null;
+                },
+              ),
+
+              SizedBox(height: 8,),
+
+              TextFormField(
+                controller: _emailController,
+                keyboardType: TextInputType.emailAddress,
+                textInputAction: TextInputAction.next,
+                decoration: InputDecoration(
+                  contentPadding: EdgeInsets.symmetric(vertical: 12),
+                  enabledBorder: UnderlineInputBorder(
+                    borderSide: BorderSide(color: Colors.grey.shade400, width: 1)
+                  ),
+                  focusedBorder: UnderlineInputBorder(
+                    borderSide: BorderSide(color: Colors.grey.shade200, width: 1.5)
+                  ),
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
+                  labelText: "이메일",
+                  hintText: "예) Walkin@walkin.co.kr",
+                  hintStyle: TextStyle(
+                    color: Colors.grey,
+                    fontSize: 14,
+                  ),
+                ),
+                validator: (value){
+                  if(_nameController.text.isEmpty){
+                    return "이메일을 입력해주세요.";
+                  }
+                  if(!RegExp(
+                      r"^[a-zA-Z0-9.a-zA-Z0-9.!#$%&'*+-/=?^_{|}~]+@[a-zA-Z0-9]+\.[a-zA-Z]+")
+                      .hasMatch(value.toString())){
+                    return "이메일은 반드시 aaa@aaa.com 형태여야 합니다.";
+                  }
+                  return null;
+                },
+              ),
+
+              SizedBox(height: 8,),
+
+              TextFormField(
+                controller: _pwController,
+                keyboardType: TextInputType.text,
+                textInputAction: TextInputAction.done,
+                obscureText: _showVisibleIcon,
+                decoration: InputDecoration(
+                  contentPadding: EdgeInsets.symmetric(vertical: 12),
+                  enabledBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(color: Colors.grey.shade400, width: 1)
+                  ),
+                  focusedBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(color: Colors.grey.shade200, width: 1.5)
+                  ),
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
+                  labelText: "비밀번호",
+                  suffixIcon: IconButton(
+                    onPressed: _changeVisibilityIcon,
+                    icon: _showVisibleIcon
+                        ? Icon(Icons.visibility_off_outlined)
+                        : Icon(Icons.visibility),
+                  ),
+                ),
+                validator: (value){
+                  if(_pwController.text.isEmpty) {
+                    return "비밀번호를 입력해주세요.";
+                  } else if(_pwController.text.length < 8){
+                    return "비밀번호는 최소 8자 이상이어야 합니다.";
+                  }
+                  return null;
+                },
+              ),
+
+              SizedBox(height: 8,),
+
+              TextFormField(
+                controller: _confirmPwController,
+                keyboardType: TextInputType.text,
+                textInputAction: TextInputAction.done,
+                obscureText: true,
+                decoration: InputDecoration(
+                  contentPadding: EdgeInsets.symmetric(vertical: 12),
+                  enabledBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(color: Colors.grey.shade400, width: 1)
+                  ),
+                  focusedBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(color: Colors.grey.shade200, width: 1.5)
+                  ),
+                  floatingLabelBehavior: FloatingLabelBehavior.always,
+                  labelText: "비밀번호 확인",
+                ),
+                validator: (value){
+                  if(_confirmPwController.text.isEmpty) {
+                    return "비밀번호를 입력해주세요.";
+                  } else if(_pwController.text != _confirmPwController.text){
+                    return "입력한 비밀번호가 다릅니다.";
+                  } else return null;
+                },
+              ),
+
+              SizedBox(height: 48,),
+
+              ElevatedButton(
+                onPressed: () {_submitForm();},
+                child: Text(
+                  "회원가입",
+                  style: TextStyle(color: Colors.white,
+                      fontSize: 18),
+                ),
+                style: ElevatedButton.styleFrom(
+                  minimumSize: Size.fromHeight(50),
+                  backgroundColor: AppColors.primaryColor,
+                  shape: RoundedRectangleBorder(
+                    borderRadius: BorderRadius.circular(32),
+                  ),
+                ),
+              ),
+            ],
+          ),
+        )
+    );
+  }
+}

--- a/lib/feature/auth/ui/signup_screen.dart
+++ b/lib/feature/auth/ui/signup_screen.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:office_shopping_mall/feature/auth/ui/auth_header.dart';
+import 'package:office_shopping_mall/feature/auth/ui/signup_form.dart';
+
+import '../../../core/widgets/custom_app_bar.dart';
+
+class SignupScreen extends StatelessWidget {
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: CustomAppBar(
+          title: "회원가입",
+          centerTitle: true,
+          titleTextStyle: GoogleFonts.notoSans(
+              fontSize: 22,
+              fontWeight: FontWeight.w900,
+            letterSpacing: 0.5
+          ),
+        ),
+        body: Padding(padding: EdgeInsets.fromLTRB(16, 48, 16, 16),
+          child:SingleChildScrollView(
+            child:  Column(
+              children: [
+                AuthHeader(),
+                // Text("회원가입 폼")
+                SignUpForm(),
+              ],
+            ),
+          ),
+        ),
+    );
+  }
+}


### PR DESCRIPTION
## 변경 내용
- 회원가입 페이지 경로 추가
- auth_header -> 로그인과 회원가입 화면 공통으로 쓰이는 부분(앱 아이콘+어플설명)은 공통 화면으로 개발
- 회원가입 폼의 입력값 마다 유효성 검증
- 비밀번호 보이기 아이콘
- 회원가입 버튼 클릭 시, 다이얼로그 띄움. 아니오->알림창닫기 / 예 -> formData를 받아옴

## 체크리스트
- [ ] 기능 정상 동작 확인
- [ ] 소스 최적화 여부 확인

 커밋을 자주하는 것이 버릇 들지 않아 마지막에 한 번만 함 이 부분은 앞으로 개선하겠습니다