### PR TITLE
[Feature] 비밀번호 변경 화면 구현

### DIFF
--- a/lib/app_router.dart
+++ b/lib/app_router.dart
@@ -9,6 +9,7 @@ import 'package:office_shopping_mall/feature/notification/ui/notification_screen
 import 'package:office_shopping_mall/feature/order/ui/order_complete_screen.dart';
 import 'package:office_shopping_mall/feature/order/ui/order_screen.dart';
 import 'package:office_shopping_mall/feature/preference/ui/preference_screen.dart';
+import 'package:office_shopping_mall/feature/setting/ui/pw_setting.dart';
 
 import 'feature/category/ui/category_screen.dart';
 import 'feature/product/ui/product_detail_screen.dart';
@@ -51,6 +52,8 @@ class AppRouter {
         return MaterialPageRoute(builder: (_) => DeliveryScreen());
       case AppRoutes.search:
         return MaterialPageRoute(builder: (_) => SearchScreen());
+      case AppRoutes.pwsetting:
+        return MaterialPageRoute(builder: (_) => PwSetting());
 
       default:
         return MaterialPageRoute(

--- a/lib/core/constants/app_routes.dart
+++ b/lib/core/constants/app_routes.dart
@@ -14,4 +14,5 @@ class AppRoutes {
   static const String notification = "/notification";
   static const String cart = "/cart";
   static const String delivery = "/delivery";
+  static const String pwsetting = '/pwsetting';
 }

--- a/lib/feature/setting/ui/pw_setting.dart
+++ b/lib/feature/setting/ui/pw_setting.dart
@@ -1,0 +1,16 @@
+import 'package:flutter/material.dart';
+import 'package:office_shopping_mall/core/widgets/app_bar/custom_app_bar.dart';
+
+class PwSetting extends StatelessWidget{
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: CustomAppBar(title: "비밀번호 변경",),
+      body: Column(
+        children: [
+          Text("하이~~~")
+        ],
+      ),
+    );
+  }
+}

--- a/lib/feature/setting/ui/pw_setting.dart
+++ b/lib/feature/setting/ui/pw_setting.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_svg/flutter_svg.dart';
+import 'package:fluttertoast/fluttertoast.dart';
 import 'package:office_shopping_mall/core/theme/app_colors.dart';
 import 'package:office_shopping_mall/core/widgets/app_bar/custom_app_bar.dart';
 
@@ -26,6 +27,8 @@ class _PwSettingState extends State<PwSetting> {
 
   void getNewPw(String newPW) {
     print('새 비밀번호는: $newPW');
+    showToast("비밀번호가 변경되었습니다.");
+    //TODO: 비밀번호 변경 api 연결
   }
 
   @override
@@ -138,4 +141,9 @@ class _PwSettingState extends State<PwSetting> {
       ),
     );
   }
+}
+
+
+void showToast(String msg) {
+  Fluttertoast.showToast(msg: msg, toastLength: Toast.LENGTH_SHORT);
 }

--- a/lib/feature/setting/ui/pw_setting.dart
+++ b/lib/feature/setting/ui/pw_setting.dart
@@ -1,15 +1,140 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_svg/flutter_svg.dart';
+import 'package:office_shopping_mall/core/theme/app_colors.dart';
 import 'package:office_shopping_mall/core/widgets/app_bar/custom_app_bar.dart';
 
-class PwSetting extends StatelessWidget{
+class PwSetting extends StatefulWidget {
+  PwSetting({super.key});
+
+  @override
+  State<StatefulWidget> createState() {
+    return _PwSettingState();
+  }
+}
+
+class _PwSettingState extends State<PwSetting> {
+  final GlobalKey<FormState> _formKey = GlobalKey<FormState>();
+  final TextEditingController _pwController = TextEditingController();
+  final TextEditingController _confirmPwController = TextEditingController();
+  bool _showVisibleIcon = true;
+
+  void _changeVisibilityIcon() {
+    setState(() {
+      _showVisibleIcon = !_showVisibleIcon;
+    });
+  }
+
+  void getNewPw(String newPW) {
+    print('새 비밀번호는: $newPW');
+  }
+
+  @override
+  void dispose() {
+    super.dispose();
+    _pwController.dispose();
+    _confirmPwController.dispose();
+  }
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: CustomAppBar(title: "비밀번호 변경",),
-      body: Column(
-        children: [
-          Text("하이~~~")
-        ],
+      appBar: CustomAppBar(title: "비밀번호 변경"),
+      bottomNavigationBar: Padding(
+        padding: EdgeInsets.only(left: 16, right: 16, bottom: 16),
+        child: ElevatedButton(
+          onPressed: () {
+            if (_formKey.currentState!.validate()) {
+              getNewPw(_confirmPwController.text);
+            }
+          },
+          child: Text("변경"),
+        ),
+      ),
+      body: Form(
+        key: _formKey,
+        child: SingleChildScrollView(
+          child: Padding(
+            padding: EdgeInsets.all(16),
+            child: Column(
+              children: [
+                TextFormField(
+                  controller: _pwController,
+                  keyboardType: TextInputType.text,
+                  textInputAction: TextInputAction.done,
+                  obscureText: _showVisibleIcon,
+                  decoration: InputDecoration(
+                    filled: false,
+                    contentPadding: EdgeInsets.symmetric(vertical: 12),
+                    enabledBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(
+                        color: AppColors.gray200,
+                        width: 1,
+                      ),
+                    ),
+                    focusedBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(
+                        color: AppColors.gray400,
+                        width: 1.5,
+                      ),
+                    ),
+                    floatingLabelBehavior: FloatingLabelBehavior.always,
+                    labelText: "새 비밀번호",
+                    suffixIcon: IconButton(
+                      onPressed: _changeVisibilityIcon,
+                      icon: _showVisibleIcon
+                          ? Icon(Icons.visibility_off_outlined)
+                          : Icon(Icons.visibility),
+                    ),
+                  ),
+                  validator: (value) {
+                    if (_pwController.text.isEmpty) {
+                      return "비밀번호를 입력해주세요.";
+                    } else if (_pwController.text.length < 8) {
+                      return "비밀번호는 최소 8자 이상이어야 합니다.";
+                    }
+                    return null;
+                  },
+                ),
+
+                SizedBox(height: 32),
+
+                TextFormField(
+                  controller: _confirmPwController,
+                  keyboardType: TextInputType.text,
+                  textInputAction: TextInputAction.done,
+                  obscureText: true,
+                  decoration: InputDecoration(
+                    filled: false,
+                    contentPadding: EdgeInsets.symmetric(vertical: 12),
+                    enabledBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(
+                        color: AppColors.gray200,
+                        width: 1,
+                      ),
+                    ),
+                    focusedBorder: UnderlineInputBorder(
+                      borderSide: BorderSide(
+                        color: AppColors.gray400,
+                        width: 1.5,
+                      ),
+                    ),
+                    floatingLabelBehavior: FloatingLabelBehavior.always,
+                    labelText: "비밀번호 확인",
+                  ),
+                  validator: (value) {
+                    if (_confirmPwController.text.isEmpty) {
+                      return "비밀번호를 입력해주세요.";
+                    } else if (_pwController.text !=
+                        _confirmPwController.text) {
+                      return "입력한 비밀번호가 다릅니다.";
+                    } else
+                      return null;
+                  },
+                ),
+              ],
+            ),
+          ),
+        ),
       ),
     );
   }


### PR DESCRIPTION
## 주요 변경 사항
- 비밀번호 변경 화면으로 이동하는 루트 추가
- 비밀번호 변경 완료시 변경되었음을 알리는 toast를 추가함(스낵바가 더 나을까요? 이 부분은 의견 부탁드립니다)

## 스크린샷 (UI 변경이 있을 경우)
![1](https://github.com/user-attachments/assets/4eb3defa-41d0-479f-83bb-237153aefba1)
![2](https://github.com/user-attachments/assets/56ba48ac-9691-4fce-a6ae-233675bd16f2)


## 체크리스트
- [x] 기능 정상 동작 확인
- [ ] 소스 최적화 여부 확인
